### PR TITLE
[Fix] Fixes Windows compilation issue when casting filepaths to strings

### DIFF
--- a/src/kernel/evolution_strategy.tcc
+++ b/src/kernel/evolution_strategy.tcc
@@ -133,7 +133,7 @@ void basic_alps_es<T, CS>::log_strategy(unsigned last_run,
 
   if (!env.stat.layers_file.empty())
   {
-    const std::string n_lys(merge_path(env.stat.dir, env.stat.layers_file));
+    const std::string n_lys(merge_path(env.stat.dir.string(), env.stat.layers_file.string()));
     std::ofstream f_lys(n_lys, std::ios_base::app);
     if (!f_lys.good())
       return;

--- a/src/kernel/search.tcc
+++ b/src/kernel/search.tcc
@@ -437,8 +437,8 @@ void search<T, ES>::log_stats(const search_stats<T> &stats) const
 
   log_stats(stats, &d);
 
-  const std::string f_sum(merge_path(prob_.env.stat.dir,
-                                     prob_.env.stat.summary_file));
+  const std::string f_sum(merge_path(prob_.env.stat.dir.string(),
+                                     prob_.env.stat.summary_file.string()));
   d.SaveFile(f_sum.c_str());
 }
 


### PR DESCRIPTION
Fixes a small bug that occurs when attempting to compile the "tests" project on Windows. 

Errors
```
vita\src\kernel/evolution_strategy.tcc(136,1): error C2664: 'std::string vita::merge_path(const std::string &,const std::string &,char)': cannot convert argument 1 from 'const std::filesystem::path' to 'const std::string &'
vita\src\kernel/evolution_strategy.tcc(136,1): message : Reason: cannot convert from 'const std::filesystem::path' to 'const std::string'
vita\src\kernel/evolution_strategy.tcc(136,48): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
vita\src\utility/utility.h(31,13): message : see declaration of 'vita::merge_path'

vita\src\kernel/search.tcc(440,27): error C2664: 'std::string vita::merge_path(const std::string &,const std::string &,char)': cannot convert argument 1 from 'std::filesystem::path' to 'const std::string &'
vita\src\kernel/search.tcc(441,1): message : Reason: cannot convert from 'std::filesystem::path' to 'const std::string'
vita\src\kernel/search.tcc(440,52): message : No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
vita\src\utility/utility.h(31,13): message : see declaration of 'vita::merge_path'
```